### PR TITLE
Add node highlighting feature.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The memorable alternatives are:
 
 Load 'tree-climber.nvim' as any other neovim plugin using your favourite package manager.
 
-The plugin provides 7 functions, that can be mapped by the user: `goto_next()`, `goto_prev()`, `goto_parent()`, `goto_child()`, `swap_next()`, `swap_prev()` and `select_node()`.
+The plugin provides 8 functions, that can be mapped by the user: `goto_next()`, `goto_prev()`, `goto_parent()`, `goto_child()`, `swap_next()`, `swap_prev()`,`select_node()` and `highlight_node()`.
 Suggested mapping for easy copy-pasting:
 ```
 local keyopts = { noremap = true, silent = true }
@@ -29,11 +29,16 @@ vim.keymap.set({'n', 'v', 'o'}, 'K', require('tree-climber').goto_prev, keyopts)
 vim.keymap.set({'v', 'o'}, 'in', require('tree-climber').select_node, keyopts)
 vim.keymap.set('n', '<c-k>', require('tree-climber').swap_prev, keyopts)
 vim.keymap.set('n', '<c-j>', require('tree-climber').swap_next, keyopts)
+vim.keymap.set('n', '<c-h>', require('tree-climber').highlight_node, keyopts)
 ```
 
 ### Configuration
 
 Each function optionally accepts a table with a configuration, for example, `goto_next({ skip_comments = true})`.
 
-The only available option so far is:
+The available options so far are:
 * `skip_comments` (boolean) - ignore comment nodes as if they were not there at all (default: false)
+* `highlight` (boolean) - When moving using the `goto_*()` functions, briefly highlight the new node (default: false)
+* `timeout` (number) - When highlighting, the time in ms before highlight is cleared (default: 150)
+* `on_macro` (boolean) - when `highlight` is true, highlight nodes even when executing a macro (default: false)
+* `higroup` (string) - the highlight group to use for highlighting (default: `'IncSearch'`)

--- a/lua/tree-climber.lua
+++ b/lua/tree-climber.lua
@@ -112,7 +112,6 @@ local function find_next_nontrivial_parent(node, parser, options)
   return node, parser
 end
 
-
 local function locate_node(path, parser, cursor, level, options)
   local next_parent, next_parser = find_next_nontrivial_parent(path[#path], parser, options)
   if not next_parent or not next_parser then
@@ -153,7 +152,6 @@ local function get_current_node_path(options)
 
   return locate_node({root}, main_parser, cursor, M._node_level, options)
 end
-
 
 local function get_next_sibling_path(path, parser, options)
   local node = path[#path]
@@ -216,7 +214,12 @@ local function goto_with(new_path_getter, options)
   end
 
   set_node_level(new_path)
-  move_cursor_to_node(new_path[#new_path])
+
+  local new_node = new_path[#new_path]
+  move_cursor_to_node(new_node)
+  if options and options.highlight then
+    require("tree-climber.highlight").highlight_node(new_node, options)
+  end
 end
 
 local function swap_with(new_path_getter, options)
@@ -233,9 +236,8 @@ local function swap_with(new_path_getter, options)
   local new_node = new_path[#new_path]
 
   set_node_level(new_path)
-  require('nvim-treesitter.ts_utils').swap_nodes(node, new_node, 0, true)
+  require("nvim-treesitter.ts_utils").swap_nodes(node, new_node, 0, true)
 end
-
 
 M.goto_next = function(options)
   goto_with(get_next_sibling_path, options)
@@ -279,6 +281,15 @@ M.select_node = function(options)
   end
 
   vim.api.nvim_win_set_cursor(0, { end_row, end_col })
+end
+
+M.highlight_node = function(options)
+  local path, parser = get_current_node_path(options)
+  if not path or not parser then
+    return
+  end
+  local node = path[#path]
+  require("tree-climber.highlight").highlight_node(node, options)
 end
 
 return M

--- a/lua/tree-climber/highlight.lua
+++ b/lua/tree-climber/highlight.lua
@@ -1,0 +1,44 @@
+-- Credit: This file has largely been adapted from `vim.highlight.on_yank`,
+-- defined in neovim/runtime/lua/vim/highlight.lua.
+
+local M = {}
+
+local ts_utils = require("nvim-treesitter.ts_utils")
+
+local node_ns = vim.api.nvim_create_namespace("tree_climber_hlnode")
+local node_timer
+
+function M.highlight_node(node, opts)
+  vim.validate {
+    node = { node, "userdata", true },
+    opts = { opts, "table", true },
+  }
+  if node == nil then
+    return
+  end
+
+  opts = opts or {}
+  local on_macro = opts.on_macro or false
+  local higroup = opts.higroup or "IncSearch"
+  local timeout = opts.timeout or 150
+
+  if not on_macro and vim.fn.reg_executing() ~= '' then
+    return
+  end
+
+  local bufnr = vim.api.nvim_get_current_buf()
+  vim.api.nvim_buf_clear_namespace(bufnr, node_ns, 0, -1)
+  if node_timer then
+    node_timer:close()
+  end
+
+  ts_utils.highlight_node(node, bufnr, node_ns, higroup)
+  node_timer = vim.defer_fn(function()
+    node_timer = nil
+    if vim.api.nvim_buf_is_valid(bufnr) then
+      vim.api.nvim_buf_clear_namespace(bufnr, node_ns, 0, -1)
+    end
+  end, timeout)
+end
+
+return M


### PR DESCRIPTION
Hello! :wave: 

I've been very impressed by this plugin. The tree navigation feels very intuitive, the usage is straight-forward and the code is very clear.

One issue that I've found, however, is that at times it feels a bit difficult to know which TS node I'm currently on. I would often use the node selection just to know whether I've currently selected a function name or the entire function call.

This PR adds a function `highlight_node()` that can be used to briefly flash the node that tree-climber is currently on. It also adds an option `highlight` to all the `goto_*()` functions that flashes the moved-to node. The flash duration can be configured with the option `timeout`, the flash color with the option `higroup`. By default, flashing does not occur when executing a macro. This can be turned on via the option `on_macro`.

The code is largely copied from the neovim builtin `vim.highlight.on_yank()`. This is how the feature is currently configured in my init.lua file:
```lua
local climber = require 'tree-climber'
vim.keymap.set({ 'v', 'o' }, 'in', climber.select_node, { silent = true })
vim.keymap.set('n', '<S-Up>', function() climber.goto_parent { highlight = true, skip_comments = true } end, { silent = true })
vim.keymap.set('n', '<S-Down>', function() climber.goto_child { highlight = true, skip_comments = true } end, { silent = true })
vim.keymap.set('n', '<S-Left>', function() climber.goto_prev { highlight = true, skip_comments = true } end, { silent = true })
vim.keymap.set('n', '<S-Right>', function() climber.goto_next { highlight = true, skip_comments = true } end, { silent = true })
vim.keymap.set('n', 'H', function() climber.highlight_node { timeout = 500 } end, { silent = true })
vim.keymap.set('n', '<.', climber.swap_prev, { silent = true })
vim.keymap.set('n', '>.', climber.swap_next, { silent = true })
```

One thing that I'm not sure of is whether tests should be added — and if yes, what these tests could look like.

I hope the feature is suitable to the project's direction and useful to have merged upstream. I completely understand if not, though. In any case, thank you for the great plugin!